### PR TITLE
Port 1.9 improvements

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/source/producer/InferSchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/InferSchemaAndValueProducer.java
@@ -16,13 +16,13 @@
 
 package com.mongodb.kafka.connect.source.producer;
 
-import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.inferDocumentSchema;
-
 import org.apache.kafka.connect.data.SchemaAndValue;
 
 import org.bson.BsonDocument;
 import org.bson.json.JsonWriterSettings;
 
+import com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema;
+import com.mongodb.kafka.connect.source.schema.BsonDocumentToSchemaOneDotEight;
 import com.mongodb.kafka.connect.source.schema.BsonValueToSchemaAndValue;
 
 final class InferSchemaAndValueProducer implements SchemaAndValueProducer {
@@ -37,8 +37,13 @@ final class InferSchemaAndValueProducer implements SchemaAndValueProducer {
 
   @Override
   public SchemaAndValue get(final BsonDocument changeStreamDocument) {
-    return bsonValueToSchemaAndValue.toSchemaAndValue(
-        inferDocumentSchema(changeStreamDocument, combineCompatibleArraySchemas),
-        changeStreamDocument);
+    if (combineCompatibleArraySchemas) {
+      return bsonValueToSchemaAndValue.toSchemaAndValue(
+          BsonDocumentToSchema.inferDocumentSchema(changeStreamDocument), changeStreamDocument);
+    } else {
+      return bsonValueToSchemaAndValue.toSchemaAndValue(
+          BsonDocumentToSchemaOneDotEight.inferDocumentSchema(changeStreamDocument),
+          changeStreamDocument);
+    }
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchema.java
@@ -16,11 +16,10 @@
 
 package com.mongodb.kafka.connect.source.schema;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import static com.mongodb.kafka.connect.source.schema.SchemaDebugHelper.prettyPrintSchemas;
+
 import java.util.Map;
-import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
@@ -34,48 +33,39 @@ import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
 
-import com.mongodb.kafka.connect.source.MongoSourceTask;
-
 public final class BsonDocumentToSchema {
-
-  static final Logger LOGGER = LoggerFactory.getLogger(MongoSourceTask.class);
-
-  private static final String SENTINEL_FOR_NULL_OR_EMPTY = "";
-  private static final String ID_FIELD = "_id";
-  private static final Schema DEFAULT_INFER_SCHEMA_TYPE = Schema.OPTIONAL_STRING_SCHEMA;
   public static final String DEFAULT_FIELD_NAME = "default";
+  private static final Logger LOGGER = LoggerFactory.getLogger(BsonDocumentToSchema.class);
+  private static final String ID_FIELD = "_id";
+  static final Schema INCOMPATIBLE_SCHEMA_TYPE = Schema.OPTIONAL_STRING_SCHEMA;
+  static final Schema SENTINEL_STRING_TYPE =
+      SchemaBuilder.type(Schema.Type.STRING).optional().build();
 
-  public static Schema inferDocumentSchema(
-      final BsonDocument document, final boolean combineCompatibleArraySchemas) {
-    Schema schema =
-        createSchemaBuilder(DEFAULT_FIELD_NAME, document, combineCompatibleArraySchemas)
-            .required()
-            .build();
-    if (combineCompatibleArraySchemas) {
-      return normalizeSchema(schema);
-    } else {
-      return schema;
-    }
+  public static Schema inferDocumentSchema(final BsonDocument document) {
+    return createSchemaBuilder(DEFAULT_FIELD_NAME, document).required().build();
   }
 
-  private static Schema inferDocumentSchema(
-      final String fieldPath,
-      final BsonDocument document,
-      final boolean combineCompatibleArraySchemas) {
-    return createSchemaBuilder(fieldPath, document, combineCompatibleArraySchemas)
-        .optional()
-        .build();
+  private static Schema inferDocumentSchema(final String fieldPath, final BsonDocument document) {
+    return createSchemaBuilder(fieldPath, document).optional().build();
+  }
+
+  private static Schema inferArraySchema(final String fieldPath, final BsonArray bsonArray) {
+    Schema combinedSchema = SENTINEL_STRING_TYPE;
+    for (final BsonValue v : bsonArray) {
+      combinedSchema = combinedSchema(combinedSchema, inferSchema(fieldPath, v));
+      if (combinedSchema == INCOMPATIBLE_SCHEMA_TYPE) {
+        break;
+      }
+    }
+    return SchemaBuilder.array(combinedSchema).name(fieldPath).optional().build();
   }
 
   private static SchemaBuilder createSchemaBuilder(
-      final String fieldPath,
-      final BsonDocument document,
-      final boolean combineCompatibleArraySchemas) {
+      final String fieldPath, final BsonDocument document) {
     SchemaBuilder builder = SchemaBuilder.struct();
     builder.name(fieldPath);
     if (document.containsKey(ID_FIELD)) {
-      builder.field(
-          ID_FIELD, inferSchema(ID_FIELD, document.get(ID_FIELD), combineCompatibleArraySchemas));
+      builder.field(ID_FIELD, inferSchema(ID_FIELD, document.get(ID_FIELD)));
     }
     document.entrySet().stream()
         .filter(kv -> !kv.getKey().equals(ID_FIELD))
@@ -84,17 +74,11 @@ public final class BsonDocumentToSchema {
             kv ->
                 builder.field(
                     kv.getKey(),
-                    inferSchema(
-                        createFieldPath(fieldPath, kv.getKey()),
-                        kv.getValue(),
-                        combineCompatibleArraySchemas)));
+                    inferSchema(createFieldPath(fieldPath, kv.getKey()), kv.getValue())));
     return builder;
   }
 
-  private static Schema inferSchema(
-      final String fieldPath,
-      final BsonValue bsonValue,
-      final boolean combineCompatibleArraySchemas) {
+  private static Schema inferSchema(final String fieldPath, final BsonValue bsonValue) {
     switch (bsonValue.getBsonType()) {
       case BOOLEAN:
         return Schema.OPTIONAL_BOOLEAN_SCHEMA;
@@ -112,72 +96,15 @@ public final class BsonDocumentToSchema {
       case TIMESTAMP:
         return Timestamp.builder().optional().build();
       case DOCUMENT:
-        return inferDocumentSchema(
-            fieldPath, bsonValue.asDocument(), combineCompatibleArraySchemas);
+        return inferDocumentSchema(fieldPath, bsonValue.asDocument());
       case ARRAY:
-        BsonArray bsonArray = bsonValue.asArray();
-        if (combineCompatibleArraySchemas) {
-          if (bsonArray.isEmpty()) {
-            return SchemaBuilder.array(
-                    SchemaBuilder.string()
-                        .optional()
-                        // Sentinel value added to detect the empty array case.
-                        .defaultValue(SENTINEL_FOR_NULL_OR_EMPTY)
-                        .build())
-                .name(fieldPath)
-                .optional()
-                .build();
-          }
-          Schema combinedSchema =
-              inferSchema(fieldPath, bsonArray.get(0), combineCompatibleArraySchemas);
-          for (int i = 1; i < bsonArray.size(); i++) {
-            combinedSchema =
-                combine(
-                    combinedSchema,
-                    inferSchema(fieldPath, bsonArray.get(i), combineCompatibleArraySchemas));
-            if (combinedSchema == null) {
-              break;
-            }
-          }
-          return combinedSchema == null
-              ? SchemaBuilder.array(DEFAULT_INFER_SCHEMA_TYPE).name(fieldPath).optional().build()
-              : SchemaBuilder.array(combinedSchema).name(fieldPath).optional().build();
-        } else {
-          List<BsonValue> values = bsonArray.getValues();
-          Schema firstItemSchema =
-              values.isEmpty()
-                  ? DEFAULT_INFER_SCHEMA_TYPE
-                  : inferSchema(fieldPath, values.get(0), false);
-          if (values.isEmpty()
-              || values.stream()
-                  .anyMatch(
-                      bv -> !Objects.equals(inferSchema(fieldPath, bv, false), firstItemSchema))) {
-            return SchemaBuilder.array(DEFAULT_INFER_SCHEMA_TYPE)
-                .name(fieldPath)
-                .optional()
-                .build();
-          }
-          return SchemaBuilder.array(
-                  inferSchema(fieldPath, bsonValue.asArray().getValues().get(0), false))
-              .name(fieldPath)
-              .optional()
-              .build();
-        }
+        return inferArraySchema(fieldPath, bsonValue.asArray());
       case BINARY:
         return Schema.OPTIONAL_BYTES_SCHEMA;
+      case NULL:
+        return SENTINEL_STRING_TYPE;
       case SYMBOL:
       case STRING:
-        return Schema.OPTIONAL_STRING_SCHEMA;
-      case NULL:
-        if (combineCompatibleArraySchemas) {
-          return SchemaBuilder.string()
-              .optional()
-              // Sentinel value added to detect the empty array case.
-              .defaultValue(SENTINEL_FOR_NULL_OR_EMPTY)
-              .build();
-        } else {
-          return SchemaBuilder.OPTIONAL_STRING_SCHEMA;
-        }
       case OBJECT_ID:
       case REGULAR_EXPRESSION:
       case DB_POINTER:
@@ -187,136 +114,83 @@ public final class BsonDocumentToSchema {
       case MAX_KEY:
       case UNDEFINED:
       default:
-        return DEFAULT_INFER_SCHEMA_TYPE;
+        return Schema.OPTIONAL_STRING_SCHEMA;
     }
   }
 
-  private static Schema combine(final Schema firstSchema, final Schema secondSchema) {
+  private static Schema combinedSchema(final Schema firstSchema, final Schema secondSchema) {
+    if (isSentinel(firstSchema)) {
+      return secondSchema;
+    } else if (isSentinel(secondSchema)) {
+      return firstSchema;
+    }
+
     if (firstSchema.equals(secondSchema)) {
       return firstSchema;
     }
 
     if (firstSchema.type() != secondSchema.type()) {
-      LOGGER.debug(
-          "Can't combine non-matching schema types: {} and {}",
-          firstSchema.type(),
-          secondSchema.type());
-      return null;
+      logIncompatibleSchemas(firstSchema, secondSchema);
+      return INCOMPATIBLE_SCHEMA_TYPE;
     }
 
-    if (firstSchema.type() != Schema.Type.STRUCT || secondSchema.type() != Schema.Type.STRUCT) {
-      LOGGER.debug("Can't combine non-equal schema that are not both structs");
-      return null;
-    }
-
-    SchemaBuilder builder = SchemaBuilder.struct().name(firstSchema.name()).optional();
-
-    for (Field firstField : firstSchema.fields()) {
-      Field secondField = secondSchema.field(firstField.name());
-      if (secondField == null || firstField.schema().equals(secondField.schema())) {
-        builder.field(firstField.name(), firstField.schema());
-      } else if (isSentinelValueSet(firstField.schema())) {
-        builder.field(secondField.name(), secondField.schema());
-      } else if (isSentinelValueSet(secondField.schema())) {
-        builder.field(firstField.name(), firstField.schema());
-      } else if (firstField.schema().type() == Schema.Type.STRUCT
-          && secondField.schema().type() == Schema.Type.STRUCT) {
-        Schema combinedSchema = combine(firstField.schema(), secondField.schema());
-        if (combinedSchema == null) {
-          LOGGER.debug(
-              "Can't combine non-matching struct fields: {} and {}", firstField, secondField);
-          return null;
-        }
-        builder.field(firstField.name(), combinedSchema);
-      } else if (firstField.schema().type() == Schema.Type.ARRAY
-          && secondField.schema().type() == Schema.Type.ARRAY) {
-        if (isSentinelValueSet(secondField.schema().valueSchema())) {
-          builder.field(firstField.name(), firstField.schema());
-        } else if (isSentinelValueSet(firstField.schema().valueSchema())) {
-          builder.field(secondField.name(), secondField.schema());
-        } else {
-          Schema combinedSchema =
-              combine(firstField.schema().valueSchema(), secondField.schema().valueSchema());
-          if (combinedSchema == null) {
-            LOGGER.debug(
-                "Can't combine non-matching array element value schema: {} and {}",
-                firstField,
-                secondField);
-            return null;
-          }
-          builder.field(
-              firstField.name(),
-              SchemaBuilder.array(combinedSchema).name(firstField.name()).optional().build());
-        }
-      } else {
-        LOGGER.debug("Can't combine non-matching fields: {} and {}", firstField, secondField);
-        return null;
-      }
-    }
-
-    for (Field secondField : secondSchema.fields()) {
-      if (firstSchema.field(secondField.name()) == null) {
-        builder.field(secondField.name(), secondField.schema());
-      }
-    }
-
-    return builder.build();
-  }
-
-  // Relies on the sentinel value added above
-  private static boolean isSentinelValueSet(final Schema schema) {
-    return schema.type() == Schema.Type.STRING
-        && SENTINEL_FOR_NULL_OR_EMPTY.equals(schema.defaultValue());
-  }
-
-  /**
-   * This method normalizes the schema that had been denormalized due to the array element
-   * schema-combining logic applied as part of schema building process.
-   */
-  private static Schema normalizeSchema(final Schema schema) {
-    switch (schema.type()) {
-      case STRUCT:
-        return normalizeStructSchema(schema);
+    switch (firstSchema.type()) {
       case ARRAY:
-        SchemaBuilder arraySchemaBuilder =
-            SchemaBuilder.array(normalizeSchema(schema.valueSchema())).name(schema.name());
-        if (schema.isOptional()) {
-          arraySchemaBuilder.optional();
+        SchemaBuilder arrayBuilder =
+            SchemaBuilder.array(
+                    combinedSchema(firstSchema.valueSchema(), secondSchema.valueSchema()))
+                .name(firstSchema.name())
+                .optional();
+        return arrayBuilder.build();
+      case STRUCT:
+        SchemaBuilder structBuilder = SchemaBuilder.struct().name(firstSchema.name()).optional();
+
+        // _id field first
+        Field id1 = firstSchema.field(ID_FIELD);
+        Field id2 = secondSchema.field(ID_FIELD);
+        if (id1 != null || id2 != null) {
+          structBuilder.field(ID_FIELD, combineFieldSchema(id1, id2));
         }
-        return arraySchemaBuilder.build();
-      case STRING:
-        SchemaBuilder stringSchemaBuilder = SchemaBuilder.string().name(schema.name());
-        if (schema.isOptional()) {
-          stringSchemaBuilder.optional();
-        }
-        return stringSchemaBuilder.build();
+        // Combine other fields in name order
+        Stream.concat(
+                firstSchema.fields().stream().map(Field::name),
+                secondSchema.fields().stream().map(Field::name))
+            .filter(name -> !name.equals(ID_FIELD))
+            .distinct()
+            .sorted()
+            .forEach(
+                name ->
+                    structBuilder.field(
+                        name,
+                        combineFieldSchema(firstSchema.field(name), secondSchema.field(name))));
+        return structBuilder.build();
       default:
-        return schema;
+        // Should be unreachable as the only non-primitive types supported are Arrays & Structs
+        logIncompatibleSchemas(firstSchema, secondSchema);
+        return INCOMPATIBLE_SCHEMA_TYPE;
     }
   }
 
-  private static Schema normalizeStructSchema(final Schema schema) {
-    SchemaBuilder builder = SchemaBuilder.struct().name(schema.name());
-    if (schema.isOptional()) {
-      builder.optional();
+  private static Schema combineFieldSchema(final Field firstField, final Field secondField) {
+    if (firstField == null) {
+      return secondField.schema();
+    } else if (secondField == null) {
+      return firstField.schema();
     }
 
-    List<Field> fields = new ArrayList<>(schema.fields());
-    fields.sort(Comparator.comparing(Field::name));
-
-    Field idField = schema.field(ID_FIELD);
-    if (idField != null) {
-      builder.field(idField.name(), normalizeSchema(idField.schema()));
+    if (firstField.schema().equals(secondField.schema())) {
+      return firstField.schema();
+    } else if (isSentinel(firstField.schema())) {
+      return secondField.schema();
+    } else if (isSentinel(secondField.schema())) {
+      return firstField.schema();
     }
 
-    for (Field cur : fields) {
-      if (cur.name().equals(ID_FIELD)) {
-        continue;
-      }
-      builder.field(cur.name(), normalizeSchema(cur.schema()));
-    }
+    return combinedSchema(firstField.schema(), secondField.schema());
+  }
 
-    return builder.build();
+  static boolean isSentinel(final Schema schema) {
+    return schema == SENTINEL_STRING_TYPE;
   }
 
   private static String createFieldPath(final String fieldPath, final String fieldName) {
@@ -324,6 +198,12 @@ public final class BsonDocumentToSchema {
       return fieldName;
     } else {
       return fieldPath + "_" + fieldName;
+    }
+  }
+
+  private static void logIncompatibleSchemas(final Schema firstSchema, final Schema secondSchema) {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Incompatible Schemas: {}", prettyPrintSchemas(firstSchema, secondSchema));
     }
   }
 

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaOneDotEight.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaOneDotEight.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.schema;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Timestamp;
+
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+public final class BsonDocumentToSchemaOneDotEight {
+
+  private static final String ID_FIELD = "_id";
+  private static final Schema DEFAULT_INFER_SCHEMA_TYPE = Schema.OPTIONAL_STRING_SCHEMA;
+  public static final String DEFAULT_FIELD_NAME = "default";
+
+  public static Schema inferDocumentSchema(final BsonDocument document) {
+    return createSchemaBuilder(DEFAULT_FIELD_NAME, document).required().build();
+  }
+
+  private static Schema inferDocumentSchema(final String fieldPath, final BsonDocument document) {
+    return createSchemaBuilder(fieldPath, document).optional().build();
+  }
+
+  private static SchemaBuilder createSchemaBuilder(
+      final String fieldPath, final BsonDocument document) {
+    SchemaBuilder builder = SchemaBuilder.struct();
+    builder.name(fieldPath);
+    if (document.containsKey(ID_FIELD)) {
+      builder.field(ID_FIELD, inferSchema(ID_FIELD, document.get(ID_FIELD)));
+    }
+    document.entrySet().stream()
+        .filter(kv -> !kv.getKey().equals(ID_FIELD))
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(
+            kv ->
+                builder.field(
+                    kv.getKey(),
+                    inferSchema(createFieldPath(fieldPath, kv.getKey()), kv.getValue())));
+    return builder;
+  }
+
+  private static Schema inferSchema(final String fieldPath, final BsonValue bsonValue) {
+    switch (bsonValue.getBsonType()) {
+      case BOOLEAN:
+        return Schema.OPTIONAL_BOOLEAN_SCHEMA;
+      case INT32:
+        return Schema.OPTIONAL_INT32_SCHEMA;
+      case INT64:
+        return Schema.OPTIONAL_INT64_SCHEMA;
+      case DOUBLE:
+        return Schema.OPTIONAL_FLOAT64_SCHEMA;
+      case DECIMAL128:
+        return Decimal.builder(bsonValue.asDecimal128().getValue().bigDecimalValue().scale())
+            .optional()
+            .build();
+      case DATE_TIME:
+      case TIMESTAMP:
+        return Timestamp.builder().optional().build();
+      case DOCUMENT:
+        return inferDocumentSchema(fieldPath, bsonValue.asDocument());
+      case ARRAY:
+        List<BsonValue> values = bsonValue.asArray().getValues();
+        Schema firstItemSchema =
+            values.isEmpty() ? DEFAULT_INFER_SCHEMA_TYPE : inferSchema(fieldPath, values.get(0));
+        if (values.isEmpty()
+            || values.stream()
+                .anyMatch(bv -> !Objects.equals(inferSchema(fieldPath, bv), firstItemSchema))) {
+          return SchemaBuilder.array(DEFAULT_INFER_SCHEMA_TYPE).name(fieldPath).optional().build();
+        }
+        return SchemaBuilder.array(inferSchema(fieldPath, bsonValue.asArray().getValues().get(0)))
+            .name(fieldPath)
+            .optional()
+            .build();
+      case BINARY:
+        return Schema.OPTIONAL_BYTES_SCHEMA;
+      case SYMBOL:
+      case STRING:
+      case NULL:
+        return Schema.OPTIONAL_STRING_SCHEMA;
+      case OBJECT_ID:
+      case REGULAR_EXPRESSION:
+      case DB_POINTER:
+      case JAVASCRIPT:
+      case JAVASCRIPT_WITH_SCOPE:
+      case MIN_KEY:
+      case MAX_KEY:
+      case UNDEFINED:
+      default:
+        return DEFAULT_INFER_SCHEMA_TYPE;
+    }
+  }
+
+  private static String createFieldPath(final String fieldPath, final String fieldName) {
+    if (fieldPath.equals(DEFAULT_FIELD_NAME)) {
+      return fieldName;
+    } else {
+      return fieldPath + "_" + fieldName;
+    }
+  }
+
+  private BsonDocumentToSchemaOneDotEight() {}
+}

--- a/src/main/java/com/mongodb/kafka/connect/source/schema/SchemaDebugHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/schema/SchemaDebugHelper.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.schema;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+
+public final class SchemaDebugHelper {
+
+  public static String prettyPrintSchema(final String name, final Schema schema) {
+    return appendSchemaInformation(new StringBuilder(), name, schema).toString();
+  }
+
+  static String prettyPrintSchemas(final Schema firstSchema, final Schema secondSchema) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(firstSchema.type());
+    builder.append(" : ");
+    builder.append(secondSchema.type());
+
+    if (firstSchema.type().isPrimitive() && secondSchema.type().isPrimitive()) {
+      return builder.toString();
+    }
+
+    builder.append("\n");
+    appendSchemaInformation(builder, "Schema one", firstSchema);
+    appendSchemaInformation(builder, "Schema two", secondSchema);
+    return builder.toString();
+  }
+
+  public static StringBuilder appendSchemaInformation(
+      final StringBuilder builder, final String name, final Schema schema) {
+    builder.append(name);
+    builder.append(":\n");
+    appendSchemaInformation(builder, schema, 0);
+    return builder;
+  }
+
+  private static void appendSchemaInformation(
+      final StringBuilder builder, final Schema schema, final int level) {
+    String padding = createPadding(level);
+    if (level > 10) {
+      builder.append(padding);
+      builder.append(" ... Very high level of nesting ...");
+      return;
+    }
+
+    switch (schema.type()) {
+      case ARRAY:
+        builder.append(padding);
+
+        StringBuilder arrayPostfix = new StringBuilder();
+        builder.append(" [");
+        arrayPostfix.append(" ]");
+        Schema valueSchema = schema.valueSchema();
+
+        while (valueSchema.type() == Schema.Type.ARRAY) {
+          builder.append(" [");
+          arrayPostfix.append(" ]");
+          valueSchema = valueSchema.valueSchema();
+        }
+
+        builder.append("\n");
+        appendSchemaInformation(builder, valueSchema, level);
+
+        builder.append(padding);
+        builder.append(arrayPostfix);
+        builder.append("\n");
+        break;
+      case STRUCT:
+        schema.fields().forEach(f -> appendFieldInformation(builder, f, level + 1));
+        break;
+      default:
+        builder.append(padding);
+        builder.append(schema.type().getName());
+        builder.append("\n");
+    }
+  }
+
+  private static void appendFieldInformation(
+      final StringBuilder builder, final Field field, final int level) {
+    String padding = createPadding(level);
+    builder.append(padding);
+    builder.append(field.name());
+    builder.append(": ");
+    builder.append(field.schema().type().getName());
+    builder.append(" (optional = ");
+    builder.append(field.schema().isOptional());
+    builder.append(")");
+    builder.append(" (name = ");
+    builder.append(field.schema().name());
+    builder.append(")");
+    builder.append("\n");
+
+    switch (field.schema().type()) {
+      case ARRAY:
+      case STRUCT:
+        appendSchemaInformation(builder, field.schema(), level);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private static String createPadding(final int level) {
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder.append(" ");
+    for (int i = 1; i <= level; i++) {
+      stringBuilder.append(" | ");
+    }
+    return stringBuilder.toString();
+  }
+
+  private SchemaDebugHelper() {}
+}

--- a/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/schema/BsonDocumentToSchemaTest.java
@@ -16,198 +16,388 @@
 
 package com.mongodb.kafka.connect.source.schema;
 
+import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.DEFAULT_FIELD_NAME;
+import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.INCOMPATIBLE_SCHEMA_TYPE;
+import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.SENTINEL_STRING_TYPE;
 import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.inferDocumentSchema;
-import static java.util.Arrays.asList;
-import static org.apache.kafka.connect.data.Schema.Type.ARRAY;
-import static org.apache.kafka.connect.data.Schema.Type.INT32;
-import static org.apache.kafka.connect.data.Schema.Type.STRING;
-import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
+import static com.mongodb.kafka.connect.source.schema.BsonDocumentToSchema.isSentinel;
+import static com.mongodb.kafka.connect.source.schema.SchemaUtils.assertSchemaEquals;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Timestamp;
 import org.junit.jupiter.api.Test;
 
-import org.bson.BsonArray;
 import org.bson.BsonDocument;
-import org.bson.BsonInt32;
-import org.bson.BsonNull;
-import org.bson.BsonString;
 
-@SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 public class BsonDocumentToSchemaTest {
 
   @Test
-  void testEmptyArray() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonDocument("innerArray", new BsonArray()),
-                        new BsonDocument(
-                            "innerArray",
-                            new BsonArray(asList(new BsonInt32(1), new BsonInt32(2)))),
-                        new BsonDocument(
-                            "innerArray",
-                            new BsonArray(asList(new BsonInt32(3), new BsonInt32(4)))))));
+  void testInferringAllBsonTypes() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + "\"array\": [{\"$numberInt\": \"1\"}, {\"$numberInt\": \"2\"}, {\"$numberInt\": \"3\"}], "
+                + "\"binary\": {\"$binary\": {\"base64\": \"S2Fma2Egcm9ja3Mh\", \"subType\": \"00\"}}, "
+                + "\"boolean\": true, "
+                + "\"code\": {\"$code\": \"int i = 0;\"}, "
+                + "\"codeWithScope\": {\"$code\": \"int x = y\", \"$scope\": {\"y\": {\"$numberInt\": \"1\"}}}, "
+                + "\"dateTime\": {\"$date\": {\"$numberLong\": \"1577836801000\"}}, "
+                + "\"decimal128\": {\"$numberDecimal\": \"1.0\"}, "
+                + "\"document\": {\"a\": {\"$numberInt\": \"1\"}}, "
+                + "\"double\": {\"$numberDouble\": \"62.0\"}, "
+                + "\"int32\": {\"$numberInt\": \"42\"}, "
+                + "\"int64\": {\"$numberLong\": \"52\"}, "
+                + "\"maxKey\": {\"$maxKey\": 1}, "
+                + "\"minKey\": {\"$minKey\": 1}, "
+                + "\"null\": null, "
+                + "\"objectId\": {\"$oid\": \"5f3d1bbde0ca4d2829c91e1d\"}, "
+                + "\"regex\": {\"$regularExpression\": {\"pattern\": \"^test.*regex.*xyz$\", \"options\": \"i\"}}, "
+                + "\"string\": \"the fox ...\", "
+                + "\"symbol\": {\"$symbol\": \"ruby stuff\"}, "
+                + "\"timestamp\": {\"$timestamp\": {\"t\": 305419896, \"i\": 5}}, "
+                + "\"undefined\": {\"$undefined\": true}"
+                + "}");
 
-    Schema schema = inferDocumentSchema(document, true);
-    assertEquals(STRUCT, schema.type());
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("array", createArray("array", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("binary", Schema.OPTIONAL_BYTES_SCHEMA)
+            .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+            .field("code", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("codeWithScope", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("dateTime", Timestamp.builder().optional().build())
+            .field("decimal128", Decimal.builder(1).optional().build())
+            .field(
+                "document",
+                SchemaBuilder.struct()
+                    .field("a", Schema.OPTIONAL_INT32_SCHEMA)
+                    .name("document")
+                    .optional()
+                    .build())
+            .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .field("int32", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("int64", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("maxKey", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("minKey", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("null", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("objectId", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("regex", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("symbol", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("timestamp", Timestamp.builder().optional().build())
+            .field("undefined", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
 
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
-
-    Schema innerArraySchema = outerArraySchema.valueSchema().field("innerArray").schema();
-    assertEquals(ARRAY, innerArraySchema.type());
-    assertEquals(INT32, innerArraySchema.valueSchema().type());
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
   }
 
   @Test
-  void testStructCombining() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonDocument()
-                            .append("a", new BsonInt32(1))
-                            .append("b", new BsonString("foo")),
-                        new BsonDocument()
-                            .append("b", new BsonString("foo"))
-                            .append("c", new BsonInt32(2)))));
+  void testArraysSimple() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + "empty: [],"
+                + "ints: [1, 2, 3],"
+                + "intsNull: [1, null, 3],"
+                + "intsNullFirst: [null, 1, 3],"
+                + "mixedTypes: [1, 'foo', {a: 1}]}");
 
-    Schema schema = inferDocumentSchema(document, true);
-    assertEquals(STRUCT, schema.type());
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("empty", createArray("empty", Schema.OPTIONAL_STRING_SCHEMA))
+            .field("ints", createArray("ints", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("intsNull", createArray("intsNull", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("intsNullFirst", createArray("intsNullFirst", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("mixedTypes", createArray("mixedTypes", Schema.OPTIONAL_STRING_SCHEMA))
+            .build();
 
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
-
-    Schema outerArrayValueSchema = outerArraySchema.valueSchema();
-    assertEquals(STRUCT, outerArrayValueSchema.type());
-
-    assertEquals(INT32, outerArrayValueSchema.field("a").schema().type());
-    assertEquals(STRING, outerArrayValueSchema.field("b").schema().type());
-    assertEquals(INT32, outerArrayValueSchema.field("c").schema().type());
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
   }
 
   @Test
-  void testStructCombiningNestedArrays() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonDocument()
-                            .append(
-                                "innerArray",
-                                new BsonArray(
-                                    asList(
-                                        new BsonDocument()
-                                            .append("a", new BsonInt32(1))
-                                            .append("b", new BsonString("foo"))))),
-                        new BsonDocument()
-                            .append(
-                                "innerArray",
-                                new BsonArray(
-                                    asList(
-                                        new BsonDocument()
-                                            .append("b", new BsonString("foo"))
-                                            .append("c", new BsonInt32(2))))))));
+  void testFieldOrderingHandling() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + " arrays: [{_a: 'foo', _id: 'foo'}, {_id: 'bar', a: ''}],"
+                + "_id: 'foo'"
+                + "_a: 'bar'}");
 
-    Schema schema = inferDocumentSchema(document, true);
-    assertEquals(STRUCT, schema.type());
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("_a", Schema.OPTIONAL_STRING_SCHEMA)
+            .field(
+                "arrays",
+                createArray(
+                    "arrays",
+                    SchemaBuilder.struct()
+                        .name("arrays")
+                        .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("_a", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("a", Schema.OPTIONAL_STRING_SCHEMA)
+                        .optional()
+                        .build()))
+            .build();
 
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
-
-    Schema outerArrayValueSchema = outerArraySchema.valueSchema();
-    assertEquals(STRUCT, outerArrayValueSchema.type());
-
-    Schema innerArraySchema = outerArrayValueSchema.field("innerArray").schema();
-    assertEquals(ARRAY, innerArraySchema.type());
-
-    Schema innerArrayValueSchema = innerArraySchema.valueSchema();
-    assertEquals(STRUCT, innerArrayValueSchema.type());
-
-    assertEquals(INT32, innerArrayValueSchema.field("a").schema().type());
-    assertEquals(STRING, innerArrayValueSchema.field("b").schema().type());
-    assertEquals(INT32, innerArrayValueSchema.field("c").schema().type());
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
   }
 
   @Test
-  void testStructCombiningWithNulls() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonDocument()
-                            .append("a", new BsonInt32(1))
-                            .append("b", new BsonString("foo"))
-                            .append("c", BsonNull.VALUE)
-                            .append("d", BsonNull.VALUE)
-                            .append("e", new BsonArray()),
-                        new BsonDocument()
-                            .append("a", BsonNull.VALUE)
-                            .append("b", new BsonString("foo"))
-                            .append("c", new BsonInt32(2)))));
+  void testArraysSimpleNesting() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + " arrays: [[1], [2], [3]],"
+                + " arraysEmpty: [[1], [], [2]],"
+                + " arraysEmptyFirst: [[], [1], [2]],"
+                + " arraysNull: [[1], null, [2]],"
+                + " arraysNullFirst: [[1], null, [2]],"
+                + " arraysWithMixedTypes: [[1], ['2'], [{a: 1}]]}");
 
-    Schema schema = inferDocumentSchema(document, true);
-    assertEquals(STRUCT, schema.type());
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("arrays", createNestedArray("arrays", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("arraysEmpty", createNestedArray("arraysEmpty", Schema.OPTIONAL_INT32_SCHEMA))
+            .field(
+                "arraysEmptyFirst",
+                createNestedArray("arraysEmptyFirst", Schema.OPTIONAL_INT32_SCHEMA))
+            .field("arraysNull", createNestedArray("arraysNull", Schema.OPTIONAL_INT32_SCHEMA))
+            .field(
+                "arraysNullFirst",
+                createNestedArray("arraysNullFirst", Schema.OPTIONAL_INT32_SCHEMA))
+            .field(
+                "arraysWithMixedTypes",
+                createNestedArray("arraysWithMixedTypes", Schema.OPTIONAL_STRING_SCHEMA))
+            .build();
 
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRUCT, outerArraySchema.valueSchema().type());
-
-    Schema outerArrayValueSchema = outerArraySchema.valueSchema();
-    assertEquals(STRUCT, outerArrayValueSchema.type());
-
-    assertEquals(INT32, outerArrayValueSchema.field("a").schema().type());
-    assertEquals(STRING, outerArrayValueSchema.field("b").schema().type());
-    assertEquals(INT32, outerArrayValueSchema.field("c").schema().type());
-    assertEquals(STRING, outerArrayValueSchema.field("d").schema().type());
-    assertNull(outerArrayValueSchema.field("d").schema().defaultValue());
-    assertEquals(STRING, outerArrayValueSchema.field("e").schema().valueSchema().type());
-    assertNull(outerArrayValueSchema.field("e").schema().valueSchema().defaultValue());
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
   }
 
   @Test
-  void testUncombinableDocumentArrayElements() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonDocument("a", new BsonArray(asList(new BsonInt32(1)))),
-                        new BsonDocument("a", new BsonArray(asList(new BsonString("foo")))))));
+  void testArraysWithStructs() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + " structs: [{a: 1, b: true, c: 'foo'}, {b: false, d: 4, e: {'$numberLong': '5'}}],"
+                + " structsEmpty: [{a: 1, b: true}, {}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
+                + " structsEmptyFirst: [{}, {a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
+                + " structsNull: [{a: 1, b: true, c : null, d: null}, null, {d: 4, e: {'$numberLong': '5'}}],"
+                + " structsNullFirst: [null, {a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}],"
+                + " structsOrdering: [{e: {'$numberLong': '5'}, c: 'foo', b: true, d: 4, a: 1}],"
+                + " structsWithMixedTypes: [{a: 1, b: 2, c: 3, d: 4, e: 5}, {a: 'a', b: 'b', c: 'c', d: 'd', e: 'e'}]}");
 
-    Schema schema = inferDocumentSchema(document, true);
-    assertEquals(STRUCT, schema.type());
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("structs", createArray("structs"))
+            .field("structsEmpty", createArray("structsEmpty"))
+            .field("structsEmptyFirst", createArray("structsEmptyFirst"))
+            .field("structsNull", createArray("structsNull"))
+            .field("structsNullFirst", createArray("structsNullFirst"))
+            .field("structsOrdering", createArray("structsOrdering"))
+            .field(
+                "structsWithMixedTypes",
+                createArray(
+                    "structsWithMixedTypes",
+                    createStruct("structsWithMixedTypes", SIMPLE_STRUCT_STRINGS)))
+            .build();
 
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRING, outerArraySchema.valueSchema().type());
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
   }
 
   @Test
-  void testUncombinableArrayArrayElements() {
-    BsonDocument document =
-        new BsonDocument()
-            .append(
-                "outerArray",
-                new BsonArray(
-                    asList(
-                        new BsonArray(asList(new BsonInt32(1))),
-                        new BsonArray(asList(new BsonString("foo"))))));
+  void testArraysWithStructsWithStructs() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + " structs: [{a: {a: 1, b: true, c: null, d: null}}, {a: {e: {'$numberLong': '5'}, c: 'foo', b: true, d: 4, a: 1}}],"
+                + " structsEmpty: [{a: {a: 1, b: true}}, {}, {a: {}}, {a: {c: 'foo'}}, {a: {d: 4, e: {'$numberLong': '5'}}}],"
+                + " structsEmptyFirst: [{a: {}}, {a: {a: 1, b: true}}, {a: {c: 'foo'}}, {a: {d: 4, e: {'$numberLong': '5'}}}],"
+                + " structsNull: [{a: {a: 1, b: true, c : null, d: null, e: null}}, {a: {d: 4, e: {'$numberLong': '5'}}}],"
+                + " structsNullFirst: [null, {a: {a: 1, b: true}}, {a: {c: 'foo'}}, {a: {d: 4, e: {'$numberLong': '5'}}}],"
+                + " structsOrdering: [{a: {e: {'$numberLong': '5'}, c: 'foo', b: true, d: 4, a: 1}}],"
+                + " structsWithMixedTypes: [{a: {a: 1, b: 2, c: 3, d: 4, e: 5}}, {a: {a: 'a', b: 'b', c: 'c', d: 'd', e: 'e'}}]}");
 
-    Schema schema = inferDocumentSchema(document, true);
-    assertEquals(STRUCT, schema.type());
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("structs", createArrayNestedStruct("structs"))
+            .field("structsEmpty", createArrayNestedStruct("structsEmpty"))
+            .field("structsEmptyFirst", createArrayNestedStruct("structsEmptyFirst"))
+            .field("structsNull", createArrayNestedStruct("structsNull"))
+            .field("structsNullFirst", createArrayNestedStruct("structsNullFirst"))
+            .field("structsOrdering", createArrayNestedStruct("structsOrdering"))
+            .field(
+                "structsWithMixedTypes",
+                createArrayNestedStruct("structsWithMixedTypes", SIMPLE_STRUCT_STRINGS))
+            .build();
 
-    Schema outerArraySchema = schema.field("outerArray").schema();
-    assertEquals(STRING, outerArraySchema.valueSchema().type());
+    Schema actual = inferDocumentSchema(bsonDocument);
+    assertSchemaEquals(expected, actual);
   }
+
+  @Test
+  void testArraysOfArraysWithStructs() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + " arrayStructs: [[{a: 1, b: true,} {c: 'foo'}], [{b: false}, {d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsEmpty: [[{a: 1, b: true}], [{}], [{c: 'foo'}], [], [{d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsEmptyFirst: [[{}], [{a: 1, b: true}, {c: 'foo'}], [{d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsNull: [[{a: 1, b: true, c: null, d: null}, null], null, [{d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsNullFirst: [null, [null], [{a: 1, b: true}, {c: 'foo'}, {d: 4, e: {'$numberLong': '5'}}]],"
+                + " arrayStructsOrdering: [[{e: {'$numberLong': '5'}, c: 'foo'}], [{b: true}], [{d: 4, a: 1}]],"
+                + " arrayStructsWithMixedTypes: [[{a: 1, b: 2, c: 3, d: 4, e: 5}], [{a: 'a', 'b': 'b'}], [{c: 'c', d: 'd', e: 'e'}]]}");
+
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("arrayStructs", createNestedArray("arrayStructs"))
+            .field("arrayStructsEmpty", createNestedArray("arrayStructsEmpty"))
+            .field("arrayStructsEmptyFirst", createNestedArray("arrayStructsEmptyFirst"))
+            .field("arrayStructsNull", createNestedArray("arrayStructsNull"))
+            .field("arrayStructsNullFirst", createNestedArray("arrayStructsNullFirst"))
+            .field("arrayStructsOrdering", createNestedArray("arrayStructsOrdering"))
+            .field(
+                "arrayStructsWithMixedTypes",
+                createNestedArray(
+                    "arrayStructsWithMixedTypes",
+                    createStruct("arrayStructsWithMixedTypes", SIMPLE_STRUCT_STRINGS)))
+            .build();
+
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
+  }
+
+  @Test
+  void testArraysWithStructsWithArrays() {
+    BsonDocument bsonDocument =
+        BsonDocument.parse(
+            "{"
+                + " structs: [{inner: [{a: 1, b: true}]}, {inner: [{c: 'foo'}]}, {inner: [{b: false, d: 4, e: {'$numberLong': '5'}}]}],"
+                + " structsEmpty: [{inner: []}, {inner: [{a: 1, b: true}]}, {inner: []}, {},"
+                + "                {inner: [{c: 'foo', d: 4}]}, {inner: [{e: {'$numberLong': '5'}}]}],"
+                + " structsEmptyFirst: [{}, {inner: [{a: 1, b: true}]}, {inner: [{c: 'foo', d: 4, e: {'$numberLong': '5'}}]}],"
+                + " structsNull: [{inner: [{a: 1, b: true, c: null, d: null}]}, null, {inner: null}, "
+                + "               {inner: [{d: 4, e: {'$numberLong': '5'}}]}],"
+                + " structsNullFirst: [null, {inner: [{a: 1, b: true}]}, {inner: [{c: 'foo', d: 4, e: {'$numberLong': '5'}}]}],"
+                + " structsOrdering: [{inner: [{e: {'$numberLong': '5'}, c:'foo', b: true}]}, {inner: [{d: 4, a: 1}]}],"
+                + " structsWithMixedTypes: [{inner: [{a: 1, b: 2, c: 3, d: 4, e: 5}]}, "
+                + "                                  {inner: [{a: 'a', b: 'b', c: 'c', d: 'd', e: 'e'}]}]}");
+
+    Schema expected =
+        SchemaBuilder.struct()
+            .name(DEFAULT_FIELD_NAME)
+            .field("structs", createNestedStructArray("structs"))
+            .field("structsEmpty", createNestedStructArray("structsEmpty"))
+            .field("structsEmptyFirst", createNestedStructArray("structsEmptyFirst"))
+            .field("structsNull", createNestedStructArray("structsNull"))
+            .field("structsNullFirst", createNestedStructArray("structsNullFirst"))
+            .field("structsOrdering", createNestedStructArray("structsOrdering"))
+            .field(
+                "structsWithMixedTypes",
+                createNestedStructArray(
+                    "structsWithMixedTypes",
+                    createArray(
+                        "structsWithMixedTypes_inner",
+                        createStruct(
+                            "structsWithMixedTypes_inner", SIMPLE_STRUCT_STRINGS.fields()))))
+            .build();
+
+    assertSchemaEquals(expected, inferDocumentSchema(bsonDocument));
+  }
+
+  @Test
+  void testSentinelType() {
+    assertEquals(SENTINEL_STRING_TYPE, INCOMPATIBLE_SCHEMA_TYPE);
+    assertFalse(isSentinel(INCOMPATIBLE_SCHEMA_TYPE));
+    assertTrue(isSentinel(SENTINEL_STRING_TYPE));
+  }
+
+  private static Schema createArray(final String name) {
+    return createArray(name, createStruct(name, SIMPLE_STRUCT));
+  }
+
+  private static Schema createArray(final String name, final Schema valueSchema) {
+    return SchemaBuilder.array(valueSchema).optional().name(name).build();
+  }
+
+  private static Schema createNestedArray(final String name) {
+    return createNestedArray(name, createStruct(name, SIMPLE_STRUCT));
+  }
+
+  private static Schema createNestedArray(final String name, final Schema valueSchema) {
+    return SchemaBuilder.array(SchemaBuilder.array(valueSchema).optional().name(name).build())
+        .optional()
+        .name(name)
+        .build();
+  }
+
+  private static Schema createNestedStructArray(final String name) {
+    return createNestedStructArray(name, createArray(name + "_inner"));
+  }
+
+  private static Schema createNestedStructArray(final String name, final Schema valueSchema) {
+    return createArray(name, createStruct(name, singletonList(new Field("inner", 0, valueSchema))));
+  }
+
+  private static Schema createStruct(final String name, final Schema schema) {
+    return createStruct(name, schema.fields());
+  }
+
+  private static Schema createArrayNestedStruct(final String name) {
+    return createArrayNestedStruct(name, SIMPLE_STRUCT);
+  }
+
+  private static Schema createArrayNestedStruct(final String name, final Schema schema) {
+    Schema struct =
+        SchemaBuilder.struct()
+            .name(name)
+            .field("a", createStruct(name + "_a", schema))
+            .optional()
+            .build();
+
+    return createArray(name, struct);
+  }
+
+  private static Schema createStruct(final String name, final List<Field> fields) {
+    SchemaBuilder builder = SchemaBuilder.struct().name(name).optional();
+    for (final Field field : fields) {
+      builder.field(field.name(), field.schema());
+    }
+    return builder.build();
+  }
+
+  private static final Schema SIMPLE_STRUCT =
+      SchemaBuilder.struct()
+          .name("default")
+          .field("a", Schema.OPTIONAL_INT32_SCHEMA)
+          .field("b", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+          .field("c", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("d", Schema.OPTIONAL_INT32_SCHEMA)
+          .field("e", Schema.OPTIONAL_INT64_SCHEMA)
+          .build();
+
+  private static final Schema SIMPLE_STRUCT_STRINGS =
+      SchemaBuilder.struct()
+          .name("default")
+          .field("a", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("b", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("c", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("d", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("e", Schema.OPTIONAL_STRING_SCHEMA)
+          .build();
 }


### PR DESCRIPTION
Keep the flag, but instead of pushing the flag all the way down into BsonDocumentToSchema, do the following

* Copy the BsonDocumentToSchema class from 1.8.0 into BsonDocumentToSchemaOneDotEight
* Copy the BsonDocumentToSchema class from 1.9.1 into BsonDocumentToSchema
* Use the flag in InferSchemaAndValueProducer to choose between the two classes